### PR TITLE
Add support for setting a custom uid:gid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ export COMPOSE_PROJECT_NAME=helloflask
 #export COMPOSE_PROFILES=postgres,redis,web,worker
 export COMPOSE_PROFILES=postgres,redis,assets,web,worker
 
+# If you're running native Linux and your uid:gid isn't 1000:1000 you can set
+# these to match your values before you build your image. You can check what
+# your uid:gid is by running `id` from your terminal.
+#export UID=1000
+#export GID=1000
+
 # In development avoid writing out bytecode to __pycache__ directories.
 #export PYTHONDONTWRITEBYTECODE=
 export PYTHONDONTWRITEBYTECODE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,14 @@ LABEL maintainer="Nick Janetakis <nick.janetakis@gmail.com>"
 
 WORKDIR /app/assets
 
+ARG UID=1000
+ARG GID=1000
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
   && apt-get clean \
+  && groupmod -g "${GID}" node && usermod -u "${UID}" -g "${GID}" node \
   && mkdir -p /node_modules && chown node:node -R /node_modules /app
 
 USER node
@@ -34,11 +38,15 @@ LABEL maintainer="Nick Janetakis <nick.janetakis@gmail.com>"
 
 WORKDIR /app
 
+ARG UID=1000
+ARG GID=1000
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential curl libpq-dev \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
   && apt-get clean \
-  && useradd --create-home python \
+  && groupadd -g "${GID}" python \
+  && useradd --create-home --no-log-init -u "${UID}" -g "${GID}" python \
   && chown python:python -R /app
 
 USER python

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Did you receive an error about a port being in use? Chances are it's because
 something on your machine is already running on port 8000. Check out the docs
 in the `.env` file for the `DOCKER_WEB_PORT_FORWARD` variable to fix this.
 
+Did you receive a permission denied error? Chances are you're running native
+Linux and your `uid:gid` aren't `1000:1000` (you can verify this by running
+`id`). Check out the docs in the `.env` file to customize the `UID` and `GID`
+variables to fix this.
+
 #### Setup the initial database:
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ x-app: &default-app
     context: "."
     target: "app"
     args:
+      - "UID=${UID:-1000}"
+      - "GID=${GID:-1000}"
       - "FLASK_DEBUG=${FLASK_DEBUG:-false}"
       - "NODE_ENV=${NODE_ENV:-production}"
   depends_on:
@@ -21,6 +23,8 @@ x-assets: &default-assets
     context: "."
     target: "assets"
     args:
+      - "UID=${UID:-1000}"
+      - "GID=${GID:-1000}"
       - "NODE_ENV=${NODE_ENV:-production}"
   env_file:
     - ".env"


### PR DESCRIPTION
This will help folks who are running native Linux with a user/group that don't have a `uid:gid` of `1000:1000`. This could be the case if they have multiple users on their system.

If you're using Docker Desktop on Windows or macOS or are running native Linux where your `uid:gid` is `1000:1000` then this won't affect you. Everything will work out of the box without having to customize anything.

I tested it by creating a different user on my system that had a `uid:gid` of  `1002:1003`. I set those values in the `.env` for both the `UID` and `GID` and things built successfully. I was also able to run everything without permission errors.

#### Testing instructions:

```sh
git clone https://github.com/nickjj/docker-flask-example helloflask
cd helloflask
git checkout feature-custom-uid-gid

cp .env.example .env

# [Uncomment and modfiy the UID/GID values in the .env file, you can search the file for it]

docker compose up --build

# Check things out at: https://localhost:8000 , you should see a page load with no errors in your terminal
```

**Please comment in this PR that things worked successfully or post the error(s) if it didn't work.**

I'm going to let this sit here until a few folks verify it works for them. I'm also going to use this time to see if there's a better way to do this. I don't really see too many other options. If anyone has any suggestions please let me know.



