### PR TITLE
Bind the development web port to localhost by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ export SECRET_KEY=insecure_key_for_dev
 # Which environment is running?
 # For Flask, it should be: "true" or "false"
 # For Node, it should be: "development" or "production"
+#
+# Debug mode enables Flask / Werkzeug development tooling. Keep the web service
+# bound to localhost when using it, and don't expose it to untrusted networks.
 #export FLASK_DEBUG=false
 #export NODE_ENV=production
 export FLASK_DEBUG=true
@@ -102,10 +105,12 @@ export DOCKER_WEB_HEALTHCHECK_TEST=/bin/true
 # Use the default in production to avoid having gunicorn directly accessible on
 # the internet since it'll very likely be behind nginx or a load balancer.
 #
-# This is being overwritten in dev to be compatible with more dev environments,
-# such as accessing your site on another local device (phone, tablet, etc.).
-#export DOCKER_WEB_PORT_FORWARD=127.0.0.1:8000
-export DOCKER_WEB_PORT_FORWARD=8000
+# Bind to localhost by default so development-only tooling such as the
+# Werkzeug debugger isn't exposed to your LAN or the public internet. If you
+# need another device to access the app, explicitly change this value and make
+# sure debug mode is disabled or the network is trusted.
+export DOCKER_WEB_PORT_FORWARD=127.0.0.1:8000
+#export DOCKER_WEB_PORT_FORWARD=8000
 
 # What volume path should be used? In dev we want to volume mount everything
 # so that we can develop our code without rebuilding our Docker images.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ cd helloflask
 cp .env.example .env
 ```
 
+The example `.env` enables Flask debug mode for local development. By default
+the web port is bound to `127.0.0.1:8000` so the development server and
+Werkzeug debugger are only reachable from your machine. If you change
+`DOCKER_WEB_PORT_FORWARD` to make the app reachable from another device, avoid
+doing that on untrusted networks while debug mode is enabled.
+
 #### Build everything:
 
 *The first time you run this it's going to take 5-10 minutes depending on your


### PR DESCRIPTION
## Summary

This PR makes the example development configuration bind the web port to localhost by default:

```sh
export DOCKER_WEB_PORT_FORWARD=127.0.0.1:8000
```

It also adds a short note in `.env.example` and the README explaining that Flask / Werkzeug debug tooling should not be exposed to untrusted networks.

## Why

The example `.env` enables `FLASK_DEBUG=true` for local development. Before this change, copying `.env.example` and running the app published the web service on all host interfaces with `DOCKER_WEB_PORT_FORWARD=8000`.

Binding to `127.0.0.1` preserves the normal local browser workflow while reducing the chance that development-only debug tooling is reachable from a LAN, VM interface, or public dev host by accident.

Closes #30.

## Verification

- `bash -n .env.example`
- `docker compose --env-file .env.example config --services`
